### PR TITLE
Compilation fix: added scope for the last case in switch

### DIFF
--- a/HeapShot.Gui.Widgets/ReferenceTreeViewer.cs
+++ b/HeapShot.Gui.Widgets/ReferenceTreeViewer.cs
@@ -525,7 +525,7 @@ namespace HeapShot.Gui.Widgets
 								return string.Format ("Objects of type <b>{0}</b> referenced by <b>{2}</b> objects have an average size of <b>{1:n0}</b> bytes", Markup.EscapeText (GetShortName (node.TypeName)), node.AverageSize, Markup.EscapeText (pname));
 						} else
 							return string.Format ("Objects of type <b>{0}</b> have an average size of <b>{1:n0}</b> bytes", Markup.EscapeText (GetShortName (node.TypeName)), node.AverageSize);
-				}
+					}
 				}
 			} else {
 				FieldReference fr = (FieldReference) ob;


### PR DESCRIPTION
It makes compilation possible with more strict compiler, for example with current Mono's trunk.
