### PR TITLE
Make heap-shot compatible with new binary format of mono profiler.

### DIFF
--- a/HeapShot.Reader/Event.cs
+++ b/HeapShot.Reader/Event.cs
@@ -4,9 +4,11 @@
 // Authors:
 //       Mike Krüger <mkrueger@novell.com>
 //       Rolf Bjarne Kvinge <rolf@xamarin.com>
+//       Łukasz Kucharski <lkucharski@antmicro.com>, <luk32@o2.pl>
 // 
 // Copyright (c) 2010 Novell, Inc (http://www.novell.com)
 // Copyright (C) 2011 Xamarin Inc. (http://www.xamarin.com)
+// Copyright (C) 2015 Antmicro Ltd. (http://antmicro.com)
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/HeapShot.Reader/Event.cs
+++ b/HeapShot.Reader/Event.cs
@@ -563,7 +563,7 @@ namespace MonoDevelop.Profiler
 			else if (exinfo == TYPE_SAMPLE_COUNTERS)
 				return new CountersEvent (reader);
 			else
-				throw new Exception ("Unknown sample event type: " + exinfo);
+				throw new ArgumentException("Unknown `TYPE_SAMPLE` event: "+exinfo);
 		}
 	}
 

--- a/HeapShot.Reader/EventVisitor.cs
+++ b/HeapShot.Reader/EventVisitor.cs
@@ -108,6 +108,16 @@ namespace MonoDevelop.Profiler
 		{
 			return null;
 		}
+
+		public virtual object Visit (RuntimeEvent heapEvent)
+		{
+			return null;
+		}
+
+		public virtual object Visit (RuntimeJitHelperEvent heapEvent)
+		{
+			return null;
+		}
 	}
 }
 

--- a/HeapShot.Reader/EventVisitor.cs
+++ b/HeapShot.Reader/EventVisitor.cs
@@ -98,6 +98,16 @@ namespace MonoDevelop.Profiler
 		{
 			return null;
 		}
+
+		public virtual object Visit (CountersEvent heapEvent)
+		{
+			return null;
+		}
+
+		public virtual object Visit (CountersDescEvent heapEvent)
+		{
+			return null;
+		}
 	}
 }
 


### PR DESCRIPTION
Hello, I know the project got a bit dusty, however we still find it useful for memory performance analysis at our company. The binary format of mono profiler for `--profile=log:heapshot` changed. Unfortunately the format is constructed in such way, that a reader needs to be able to parse full binary. This makes current master version virtually unusable because of unknown event types.

I would like to provide patches which make the event reader able to parse new event types, and consume whole heapshot file, effectively making the application useful again.