### PR TITLE
[build] Fix syntax error in AM_INIT_AUTOMAKE

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1,5 +1,5 @@
 AC_INIT(heap-shot.sln)
-AM_INIT_AUTOMAKE(heap-shot, 0.2)
+AM_INIT_AUTOMAKE([heap-shot], [0.2])
 AC_PROG_CC
 
 AC_PATH_PROG(MCS, mcs)


### PR DESCRIPTION
Looks like this is the correct syntax?

I was trying to use `make mac-dmg` in md-addins and couldn't execute `autogen.sh` without hitting these errors:
`./configure: line 1728: syntax error near unexpected token "heap-shot,"`
`./configure: line 1728: AM_INIT_AUTOMAKE(heap-shot, 0.2)`